### PR TITLE
Fetch d3.js from a cdn to make the site load faster

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
         <!-- =============================================================================================== Scripts -->
         <script src="js/libs/jquery-1.9.1.js"></script>
         <script src="js/libs/moment.js"></script>
-        <script src="http://d3js.org/d3.v3.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.4.2/d3.min.js"></script>
         <!-- ember -->
         <script src="js/libs/handlebars-1.0.0.js"></script>
         <script src="js/libs/ember-1.1.2.js"></script>


### PR DESCRIPTION
As the title says moving d3.js to a CDN makes the site load faster.
